### PR TITLE
Introduce version checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ what is loaded in this configuration.
 
 ## Gems' versions
 
-This configuration was originally written based on these versions:
-- rubocop (1.72.2)
-- rubocop-performance (1.24.0)
-- rubocop-rspec (3.5.0)
+This configuration is written based on these versions:
+- rubocop (1.76.0)
+- rubocop-performance (1.25.0)
+- rubocop-rspec (3.6.0)
 
 However, the only hard requirement is `"rubocop", "~> 1.0"`.
 All cops introduced later, and all plugins' cops are protected by version checks.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,28 @@
 
 My [RuboCop](https://rubygems.org/gems/rubocop) configuration to be shared between different projects.
 
+Similar in spirit to [rubocop-rails-omakase](https://github.com/rails/rubocop-rails-omakase),
+but with actual rules and style.
+
 This configuration is somewhat opinionated and does not always conform to Ruby style guide.
 It will also probably change over time.
 
 Currently contains configuration for:
-- rubocop
-- rubocop-performance
-- rubocop-rspec
+- [rubocop](https://github.com/rubocop/rubocop)
+- [rubocop-performance](https://github.com/rubocop/rubocop-performance)
+- [rubocop-rspec](https://github.com/rubocop/rubocop-rspec)
+
+> [!TIP]
+> Recommended extra plugins:
+> - [rubocop-packaging](https://github.com/utkarsh2102/rubocop-packaging)
+> - [rubocop-rake](https://github.com/rubocop/rubocop-rake)
+> - [rubocop-thread_safety](https://github.com/rubocop/rubocop-thread_safety)
+>
+> Even more extra for Rails projects:
+> - [rubocop-capybara](https://github.com/rubocop/rubocop-capybara)
+> - [rubocop-factory_bot](https://github.com/rubocop/rubocop-factory_bot)
+> - [rubocop-rails](https://github.com/rubocop/rubocop-rails)
+> - [rubocop-rspec_rails](https://github.com/rubocop/rubocop-rspec_rails)
 
 ## Usage
 
@@ -17,17 +32,32 @@ Puts this in your `.rubocop.yml` (custom file locations are not supported):
 inherit_from:
   - https://raw.githubusercontent.com/trinistr/rubocop-config/main/rubocop.yml
 
-# `require:` before rubocop 1.72
 plugins:
   - rubocop-performance
   - rubocop-rspec
   # ...other plugins
+# require:
+#  # older plugins
 
-# Your configuration here
+# Your configuration goes here
 ```
 
 RuboCop will download the configuration from GitHub and cache it locally.
 When the configuration changes, RuboCop will download the new version automatically.
+
+> [!NOTE]
+> The plugin system is supported in RuboCop 1.72+. In earlier versions, use `require` instead of `plugins`.
+
+<details>
+<summary>Why is `.rubocop.yml` required?</summary>
+
+RuboCop fails on at least some cops if they are configured, but the plugins are not loaded.
+As ERB preprocessing happens on file load, before we can determine the full configuration,
+we have to manually check a known file to determine what cops to enable.
+
+Sadly, this means that additional plugins' activation in subfolders will not influence
+what is loaded in this configuration.
+</details>
 
 ## Gems' versions
 
@@ -36,11 +66,24 @@ This configuration was originally written based on these versions:
 - rubocop-performance (1.24.0)
 - rubocop-rspec (3.5.0)
 
-Later versions should probably work (unless a major version changes cops), previous versions probably will work too.
+However, the only hard requirement is `"rubocop", "~> 1.0"`.
+All cops introduced later, and all plugins' cops are protected by version checks.
+Later versions of gems will probably work, unless a major version changes cops too much.
 
-## Configuration
+## Additional configuration
 
 Using all or any of RuboCop plugins is not required, you can just not include them in your config.
-All plugin cops' configurations are surrounded with a `grep` test, as RuboCop does not like unknown cop configurations (this creates a requirement for a root `.rubocop.yml` file).
+All plugin cops' configurations are surrounded with a `grep` test, so they won't activate if the plugin is not included.
 
 Cop settings can be overridden as usual, see [RuboCop Configuration](https://docs.rubocop.org/rubocop/configuration.html), especially [inheritance](https://docs.rubocop.org/rubocop/configuration.html#inheritance) section for details.
+
+## Other interesting plugins
+
+All rubocop gems can be found at [RubyGems](https://rubygems.org/search?query=rubocop).
+Official plugins are available under [rubocop organization on GitHub](https://github.com/orgs/rubocop/repositories).
+
+These are plugins I found interesting and worth considering:
+- [rubocop-config-prettier](https://github.com/xinminlabs/rubocop-config-prettier)
+- [rubocop-md](https://github.com/rubocop/rubocop-md)
+- [rubocop-obsession](https://github.com/jeromedalbert/rubocop-obsession)
+- [rubocop-yard](https://github.com/ksss/rubocop-yard)

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -120,9 +120,19 @@ Naming/MemoizedInstanceVariableName:
   EnforcedStyleForLeadingUnderscores: optional
 Naming/MethodParameterName:
   AllowNamesEndingInNumbers: false
+<% if rubocop_version >= '1.76' %>
+Naming/PredicateMethod:
+  # There are way too many false positives for this cop,
+  # it's better to have your own good judgement..
+  Enabled: false
+<% end %>
+<% if rubocop_version < '1.76' %>
 Naming/PredicateName:
+<% else %>
+Naming/PredicatePrefix:
+<% end %>
   # I feel that removing "has" prefix makes method names clunky. "have" is just weird though.
-  ForbiddenPrefixes: ['is_', 'have_']
+  ForbiddenPrefixes: ['is_', 'have_', 'does_']
 <% if rubocop_version >= '1.4' %>
 Naming/VariableNumber:
   EnforcedStyle: snake_case

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,3 +1,8 @@
+<%
+  rubocop_version = Gem::Version.new(RuboCop::Version::STRING)
+  raise "RuboCop versions below 1.0 are not supported" if rubocop_version < '1.0'
+%>
+
 AllCops:
   NewCops: enable
 
@@ -8,9 +13,12 @@ Bundler/OrderedGems: &ordered_dependencies
   # If comments are used as group separators, every single commented gem starts a new group.
   TreatCommentsAsGroupSeparators: false
 
+<% if rubocop_version >= '1.29' %>
 Gemspec/DependencyVersion:
   # Gems should list supported versions, as there is no lockfile to ensure compatibility.
   Enabled: true
+<% end %>
+<% if rubocop_version >= '1.44' %>
 Gemspec/DevelopmentDependencies:
   # See https://github.com/orgs/rubygems/discussions/5065.
   # The gist is: specifying development dependencies in the gemspec is unclear and doesn't work well,
@@ -18,11 +26,44 @@ Gemspec/DevelopmentDependencies:
   # Bundler is a part of RubyGems, and using it for development is almost always superior.
   Enabled: true
   EnforcedStyle: Gemfile
+<% end %>
 Gemspec/OrderedDependencies:
   <<: *ordered_dependencies
 
 Layout/ClassStructure:
   Enabled: true
+  ExpectedOrder:
+     - module_inclusion
+     - constants
+     - association
+     - macros
+     - public_class_methods
+     - public_attribute_macros
+     - public_delegate
+     - initializer
+     - public_methods
+     - protected_attribute_macros
+     - protected_methods
+     - private_attribute_macros
+     - private_delegate
+     - private_methods
+  Categories:
+    module_inclusion:
+      - include
+      - prepend
+      - extend
+    attribute_macros:
+      - attr_accessor
+      - attr_reader
+      - attr_writer
+    association:
+      - has_many
+      - has_and_belongs_to_many
+      - has_one
+      - belongs_to
+    macros:
+      - validates
+      - validate
 Layout/EndOfLine:
   EnforcedStyle: lf
 Layout/ExtraSpacing:
@@ -41,19 +82,27 @@ Layout/LineLength:
   Max: 100
 Layout/MultilineAssignmentLayout:
   Enabled: true
+<% if rubocop_version >= '1.13' %>
 Layout/RedundantLineBreak:
   Enabled: true
   InspectBlocks: true
+<% end %>
 
+<% if rubocop_version >= '1.13' %>
 Lint/AmbiguousBlockAssociation:
   AllowedMethods: ['change', 'not_change']
+<% end %>
 Lint/HeredocMethodCallPosition:
   Enabled: true
 
 Metrics:
   Severity: refactor
 Metrics/BlockLength: &count_as_one
-  CountAsOne: ['array', 'hash', 'heredoc', 'method_call']
+  CountAsOne:
+    - array
+    - hash
+    - heredoc
+<% if rubocop_version >= '1.5' %>    - method_call <% end %>
 Metrics/ClassLength:
   <<: *count_as_one
 Metrics/MethodLength:
@@ -62,8 +111,10 @@ Metrics/MethodLength:
 Metrics/ModuleLength:
   <<: *count_as_one
 
+<% if rubocop_version >= '1.18' %>
 Naming/InclusiveLanguage:
   Enabled: true
+<% end %>
 Naming/MemoizedInstanceVariableName:
   EnforcedStyleForLeadingUnderscores: optional
 Naming/MethodParameterName:
@@ -71,15 +122,35 @@ Naming/MethodParameterName:
 Naming/PredicateName:
   # I feel that removing "has" prefix makes method names clunky. "have" is just weird though.
   ForbiddenPrefixes: ['is_', 'have_']
+<% if rubocop_version >= '1.4' %>
 Naming/VariableNumber:
   EnforcedStyle: snake_case
-  AllowedPatterns: ['_v\d+\z', '\Av\d+\z']
+  AllowedPatterns:
+    # API_V1, API_V1_URL, v1_url, v1, etc.
+    - '(?:\A|_)[Vv]\d+(?:\z|_)'
+  AllowedIdentifiers:
+    - abs2
+    # Default values:
+    - TLS1_1
+    - TLS1_2
+    - capture3
+    - iso8601
+    - rfc1123_date
+    - rfc822
+    - rfc2822
+    - rfc3339
+    - x86_64
+<% end %>
 
+<% if rubocop_version < '1.21' %>
+Style/AsciiComments:
+  Enabled: false
+<% end %>
 Style/AutoResourceCleanup:
   Enabled: true
 Style/BlockDelimiters:
   # Pretty much all editors have support for braces, but do-end requires Ruby syntax support.
-  # Honestly, "always_braces" is probably the best option, but I'm too used to do-end by now.
+  # However, braces don't support implicit begin-end blocks.
   EnforcedStyle: braces_for_chaining
 Style/CaseEquality:
   # This may be confusing for JS developers, but the operator is very useful.
@@ -88,8 +159,10 @@ Style/CollectionMethods:
   Enabled: true
 Style/CommandLiteral:
   EnforcedStyle: mixed
+<% if rubocop_version >= '1.44' %>
 Style/ComparableClamp:
   Enabled: true
+<% end %>
 Style/DocumentationMethod:
   Enabled: true
   AllowedMethods: ['method_missing', 'respond_to_missing?']
@@ -98,11 +171,12 @@ Style/EmptyElse:
   AllowComments: true
 Style/HashSyntax:
   EnforcedStyle: ruby19_no_mixed_keys
-  # Debatable, "either" can also be a good option. But maybe "always" is superior?
-  EnforcedShorthandSyntax: either_consistent
+Style/IpAddresses:
+  Enabled: true
+  AllowedAddresses: ['127.0.0.1', '::1']
 Style/Lambda:
   # Not sure why the style guide recommends incosistent usage.
-  # The only problem is that braces don't work with `rescue`.
+  # Be aware that braces don't support implicit begin-end blocks.
   EnforcedStyle: literal
 Style/LambdaCall:
   # Why not use it if it looks good?
@@ -120,8 +194,10 @@ Style/MultilineBlockChain:
   Enabled: false
 Style/MultilineMethodSignature:
   Enabled: true
+<% if rubocop_version >= '1.1' %>
 Style/MultipleComparison:
   ComparisonsThreshold: 3
+<% end %>
 Style/NegatedIf:
   # `unless` in block form always confuses me.
   EnforcedStyle: postfix
@@ -130,9 +206,11 @@ Style/NumberedParametersLimit:
   Max: 2
 Style/NumericLiterals:
   # Values under 99999 are fine to read. This also includes port numbers.
-  AllowedPatterns: ['\d{4,5}']
+  MinDigits: 6
+<% if rubocop_version >= '1.23' %>
 Style/OpenStructUse:
   Enabled: true
+<% end %>
 Style/OptionHash:
   Enabled: true
 Style/PercentQLiterals:
@@ -140,25 +218,35 @@ Style/PercentQLiterals:
   EnforcedStyle: upper_case_q
 Style/RedundantFetchBlock:
   SafeForConstants: true
+<% if rubocop_version >= '1.40' %>
+Style/RequireOrder:
+  Enabled: true
+<% end %>
 Style/RescueStandardError:
   EnforcedStyle: implicit
 Style/Send:
   Enabled: true
+<% if rubocop_version >= '1.3' %>
 Style/StaticClass:
   Enabled: true
+<% end %>
 Style/StringLiterals:
   # No special handling for literal single quote as apostrophe, nor for escapes.
   EnforcedStyle: double_quotes
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
+<% if rubocop_version >= '1.40' %>
 Style/SymbolProc:
   # Unsure about this one.
   Enabled: true
   AllowMethodsWithArguments: true
+<% end %>
 Style/TernaryParentheses:
   EnforcedStyle: require_parentheses_when_complex
+<% if rubocop_version >= '1.15' %>
 Style/TopLevelMethodDefinition:
   Enabled: true
+<% end %>
 Style/TrailingCommaInArguments: &multiline_comma
   # Using `comma` style is better for moving things around and for git changes.
   EnforcedStyleForMultiline: no_comma
@@ -166,48 +254,79 @@ Style/TrailingCommaInArrayLiteral:
   <<: *multiline_comma
 Style/TrailingCommaInHashLiteral:
   <<: *multiline_comma
+<% if rubocop_version >= '1.11' %>
 Style/UnlessLogicalOperators:
-  Enabled: true
-
-<% if !`grep -- '^ *- rubocop-performance' .rubocop.yml`.empty? %>
-Performance/IoReadlines:
-  Enabled: true
-Performance/MapCompact:
-  Enabled: true
-Performance/MapMethodChain:
-  Enabled: true
-Performance/MethodObjectAsBlock:
-  Enabled: true
-Performance/SelectMap:
   Enabled: true
 <% end %>
 
+<% if !`grep -- '^ *- rubocop-performance' .rubocop.yml`.empty? %>
+<% performance_version = Gem::Version.new(RuboCop::Performance::Version::STRING) %>
+<% if performance_version >= '1.7' %>
+Performance/IoReadlines:
+  Enabled: true
+<% end %>
+<% if performance_version >= '1.11' %>
+Performance/MapCompact:
+  Enabled: true
+<% end %>
+<% if performance_version >= '1.19' %>
+Performance/MapMethodChain:
+  Enabled: true
+<% end %>
+<% if performance_version >= '1.9' %>
+Performance/MethodObjectAsBlock:
+  Enabled: true
+<% end %>
+<% if performance_version >= '1.11' %>
+Performance/SelectMap:
+  Enabled: true
+<% end %>
+<% end %>
+
 <% if !`grep -- '^ *- rubocop-rspec' .rubocop.yml`.empty? %>
+<% rspec_version = Gem::Version.new(RuboCop::RSpec::Version::STRING) %>
+<% if rspec_version >= '2.10' %>
 RSpec/BeNil:
   EnforcedStyle: be
+<% end %>
+<% if rspec_version >= '1.20' %>
 RSpec/ContextWording:
-  Prefixes: ['when', 'with', 'without', 'if']
-RSpec/DescribeClass:
-  IgnoredMetadata:
-    type: ['interaction']
+  Prefixes: ['when', 'with', 'without', 'if', 'and']
+<% end %>
+<% if rspec_version >= '1.0' %>
 RSpec/DescribedClass:
   # A fairly common case is defining an anonymous class, where `described_class` is not available.
   SkipBlocks: true
+<% end %>
+<% if rspec_version >= '1.37' %>
 RSpec/DescribedClassModuleWrapping:
   Enabled: true
+<% end %>
+<% if rspec_version >= '2.3' %>
 RSpec/ExampleLength:
   <<: *count_as_one
+<% end %>
+<% if rspec_version >= '2.13' %>
 RSpec/ExampleWording:
   DisallowedExamples: ['works', 'happy path']
+<% end %>
+<% if rspec_version >= '1.9' %>
 RSpec/MessageSpies:
   # It makes more sense to use that which makes more sense.
   Enabled: false
+<% end %>
+<% if rspec_version >= '1.21' %>
 RSpec/MultipleExpectations:
   # Sometimes it makes sense to check several things consecutively.
   Max: 3
+<% end %>
+<% if rspec_version >= '1.43' %>
 RSpec/MultipleMemoizedHelpers:
   # Helpers shared between examples may cause a larger-than-usual amount to be available.
   Max: 10
+<% end %>
+<% if rspec_version >= '2.13' %>
 RSpec/NestedGroups:
-  Max: 4
+  AllowedGroups: ['describe', 'path']
+<% end %>
 <% end %>

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -133,6 +133,8 @@ Naming/PredicatePrefix:
 <% end %>
   # I feel that removing "has" prefix makes method names clunky. "have" is just weird though.
   ForbiddenPrefixes: ['is_', 'have_', 'does_']
+  # Older RuboCop installation goes mad if "does_" is not included explicitly.
+  NamePrefix: ['is_', 'have_', 'does_']
 <% if rubocop_version >= '1.4' %>
 Naming/VariableNumber:
   EnforcedStyle: snake_case

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -170,6 +170,15 @@ Style/DocumentationMethod:
 Style/EmptyElse:
   EnforcedStyle: empty
   AllowComments: true
+<% if rubocop_version >= '1.73' %>
+Style/EndlessMethod:
+  Enabled: true
+  EnforcedStyle: require_single_line
+<% end %>
+<% if rubocop_version >= '1.77' %>
+Style/FetchEnvVar:
+  DefaultToNil: false
+<% end %>
 Style/HashSyntax:
   EnforcedStyle: ruby19_no_mixed_keys
 Style/IpAddresses:
@@ -253,8 +262,14 @@ Style/TrailingCommaInArguments: &multiline_comma
   EnforcedStyleForMultiline: no_comma
 Style/TrailingCommaInArrayLiteral:
   <<: *multiline_comma
+<% if rubocop_version >= '1.73' %>
+  EnforcedStyleForMultiline: diff_comma
+<% end %>
 Style/TrailingCommaInHashLiteral:
   <<: *multiline_comma
+<% if rubocop_version >= '1.73' %>
+  EnforcedStyleForMultiline: diff_comma
+<% end %>
 <% if rubocop_version >= '1.11' %>
 Style/UnlessLogicalOperators:
   Enabled: true
@@ -310,6 +325,12 @@ RSpec/ExampleLength:
 <% if rspec_version >= '2.13' %>
 RSpec/ExampleWording:
   DisallowedExamples: ['works', 'happy path']
+<% end %>
+<% if rspec_version >= '3.6' %>
+RSpec/IncludeExamples:
+  # Changing `include_examples` to `it_behaves_like` can break things easily.
+  # And this is kind of the purpose of this cop!
+  Enabled: false
 <% end %>
 <% if rspec_version >= '1.9' %>
 RSpec/MessageSpies:

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,10 +1,11 @@
+AllCops:
+  # Automatically enable pending cops.
+  NewCops: enable
+
 <%
   rubocop_version = Gem::Version.new(RuboCop::Version::STRING)
   raise "RuboCop versions below 1.0 are not supported" if rubocop_version < '1.0'
 %>
-
-AllCops:
-  NewCops: enable
 
 Bundler/GemComment:
   Enabled: true

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -180,11 +180,6 @@ Style/DocumentationMethod:
 Style/EmptyElse:
   EnforcedStyle: empty
   AllowComments: true
-<% if rubocop_version >= '1.73' %>
-Style/EndlessMethod:
-  Enabled: true
-  EnforcedStyle: require_single_line
-<% end %>
 <% if rubocop_version >= '1.77' %>
 Style/FetchEnvVar:
   DefaultToNil: false


### PR DESCRIPTION
Previously, there was a dependency on minimal (and maximal) versions of gems. Now, cop configuration is surrounded with version checks. The only requirement now is using rubocop >= 1.0.

Additionally, README was updated to provide more details and recommended plugins.